### PR TITLE
fix: Resolve WeatherTest failure for 0 HP damage calculation

### DIFF
--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -72,6 +72,10 @@ int Weather::getWeatherDamage(WeatherCondition weather, int maxHP) {
   switch (weather) {
   case WeatherCondition::SANDSTORM:
   case WeatherCondition::HAIL:
+    // No damage if Pokemon has 0 HP (already fainted)
+    if (maxHP <= 0) {
+      return 0;
+    }
     return std::max(1, maxHP / 16); // 1/16 max HP damage, minimum 1
   case WeatherCondition::RAIN:
   case WeatherCondition::SUN:


### PR DESCRIPTION
Fixed getWeatherDamage() to return 0 when maxHP is 0 or negative. Fainted Pokemon (0 HP) should not take weather damage.

WeatherTest now passes all 14/14 tests.