### PR TITLE
Add .gitattributes to fix GitHub language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Exclude build system files from GitHub language statistics
+CMakeLists.txt linguist-vendored
+**/CMakeLists.txt linguist-vendored
+*.cmake linguist-vendored
+build/ linguist-vendored
+
+# Exclude other non-code files that might skew stats
+*.md linguist-documentation
+*.json linguist-data
+data/ linguist-vendored


### PR DESCRIPTION
- Mark CMake files as vendored to exclude from language stats
- Mark data files and documentation appropriately
- Should now show ~99% C++ instead of 85% C++/15% CMake