### PR TITLE
fix: update test Pokemon data to comply with validation rules

### DIFF
--- a/tests/data/pokemon/testmon1.json
+++ b/tests/data/pokemon/testmon1.json
@@ -1,1 +1,0 @@
-{"name": "testmon1", "id": 1001, "types": ["normal"], "base_stats": {"hp": 100, "attack": 80, "defense": 70, "special-attack": 90, "special-defense": 85, "speed": 75}}

--- a/tests/data/pokemon/testmon2.json
+++ b/tests/data/pokemon/testmon2.json
@@ -1,1 +1,0 @@
-{"name": "testmon2", "id": 1002, "types": ["fire"], "base_stats": {"hp": 90, "attack": 85, "defense": 65, "special-attack": 95, "special-defense": 80, "speed": 85}}

--- a/tests/data/pokemon/testmon3.json
+++ b/tests/data/pokemon/testmon3.json
@@ -1,1 +1,0 @@
-{"name": "testmon3", "id": 1003, "types": ["water"], "base_stats": {"hp": 110, "attack": 75, "defense": 80, "special-attack": 85, "special-defense": 90, "speed": 70}}

--- a/tests/data/pokemon/testmona.json
+++ b/tests/data/pokemon/testmona.json
@@ -1,0 +1,1 @@
+{"name": "testmona", "id": 901, "types": ["normal"], "base_stats": {"hp": 100, "attack": 80, "defense": 70, "special-attack": 90, "special-defense": 85, "speed": 75}}

--- a/tests/data/pokemon/testmonb.json
+++ b/tests/data/pokemon/testmonb.json
@@ -1,0 +1,1 @@
+{"name": "testmonb", "id": 902, "types": ["fire"], "base_stats": {"hp": 90, "attack": 85, "defense": 65, "special-attack": 95, "special-defense": 80, "speed": 85}}

--- a/tests/data/pokemon/testmonc.json
+++ b/tests/data/pokemon/testmonc.json
@@ -1,0 +1,1 @@
+{"name": "testmonc", "id": 903, "types": ["water"], "base_stats": {"hp": 110, "attack": 75, "defense": 80, "special-attack": 85, "special-defense": 90, "speed": 70}}

--- a/tests/unit/test_team.cpp
+++ b/tests/unit/test_team.cpp
@@ -8,18 +8,18 @@ protected:
         TestUtils::PokemonTestFixture::SetUp();
         
         // Create test Pokemon
-        testPokemon1 = TestUtils::createTestPokemon("testmon1", 100, 80, 70, 90, 85, 75, {"normal"});
-        testPokemon2 = TestUtils::createTestPokemon("testmon2", 90, 85, 65, 95, 80, 85, {"fire"});
-        testPokemon3 = TestUtils::createTestPokemon("testmon3", 110, 75, 80, 85, 90, 70, {"water"});
+        testPokemon1 = TestUtils::createTestPokemon("testmona", 100, 80, 70, 90, 85, 75, {"normal"});
+        testPokemon2 = TestUtils::createTestPokemon("testmonb", 90, 85, 65, 95, 80, 85, {"fire"});
+        testPokemon3 = TestUtils::createTestPokemon("testmonc", 110, 75, 80, 85, 90, 70, {"water"});
         
         // Create test team data
-        teamData["TestTeam"] = {"testmon1", "testmon2", "testmon3"};
+        teamData["TestTeam"] = {"testmona", "testmonb", "testmonc"};
         
         // Create moves data
         movesData["TestTeam"] = {
-            {"testmon1", {"testmove"}},
-            {"testmon2", {"testmove"}},
-            {"testmon3", {"testmove"}}
+            {"testmona", {"testmove"}},
+            {"testmonb", {"testmove"}},
+            {"testmonc", {"testmove"}}
         };
     }
     
@@ -57,9 +57,9 @@ TEST_F(TeamTest, LoadTeamFromConfiguration) {
     ASSERT_NE(pokemon2, nullptr);
     ASSERT_NE(pokemon3, nullptr);
     
-    EXPECT_EQ(pokemon1->name, "testmon1");
-    EXPECT_EQ(pokemon2->name, "testmon2");
-    EXPECT_EQ(pokemon3->name, "testmon3");
+    EXPECT_EQ(pokemon1->name, "testmona");
+    EXPECT_EQ(pokemon2->name, "testmonb");
+    EXPECT_EQ(pokemon3->name, "testmonc");
 }
 
 // Test getPokemon method
@@ -70,15 +70,15 @@ TEST_F(TeamTest, GetPokemon) {
     // Test valid indices
     Pokemon* pokemon = team.getPokemon(0);
     ASSERT_NE(pokemon, nullptr);
-    EXPECT_EQ(pokemon->name, "testmon1");
+    EXPECT_EQ(pokemon->name, "testmona");
     
     pokemon = team.getPokemon(1);
     ASSERT_NE(pokemon, nullptr);
-    EXPECT_EQ(pokemon->name, "testmon2");
+    EXPECT_EQ(pokemon->name, "testmonb");
     
     pokemon = team.getPokemon(2);
     ASSERT_NE(pokemon, nullptr);
-    EXPECT_EQ(pokemon->name, "testmon3");
+    EXPECT_EQ(pokemon->name, "testmonc");
     
     // Test invalid index
     pokemon = team.getPokemon(10);
@@ -99,7 +99,7 @@ TEST_F(TeamTest, GetPokemonConst) {
     // Test valid indices
     const Pokemon* pokemon = constTeam.getPokemon(0);
     ASSERT_NE(pokemon, nullptr);
-    EXPECT_EQ(pokemon->name, "testmon1");
+    EXPECT_EQ(pokemon->name, "testmona");
     
     // Test invalid index
     pokemon = constTeam.getPokemon(10);
@@ -144,8 +144,8 @@ TEST_F(TeamTest, GetAlivePokemon) {
     EXPECT_EQ(alivePokemon.size(), 2);
     
     // Verify the alive Pokemon are correct
-    EXPECT_EQ(alivePokemon[0]->name, "testmon2");
-    EXPECT_EQ(alivePokemon[1]->name, "testmon3");
+    EXPECT_EQ(alivePokemon[0]->name, "testmonb");
+    EXPECT_EQ(alivePokemon[1]->name, "testmonc");
     
     // Faint all Pokemon
     for (size_t i = 0; i < team.size(); ++i) {
@@ -168,7 +168,7 @@ TEST_F(TeamTest, GetFirstAlivePokemon) {
     // First Pokemon should be alive
     Pokemon* firstAlive = team.getFirstAlivePokemon();
     ASSERT_NE(firstAlive, nullptr);
-    EXPECT_EQ(firstAlive->name, "testmon1");
+    EXPECT_EQ(firstAlive->name, "testmona");
     
     // Faint first Pokemon
     Pokemon* pokemon1 = team.getPokemon(0);
@@ -178,7 +178,7 @@ TEST_F(TeamTest, GetFirstAlivePokemon) {
     // Second Pokemon should now be first alive
     firstAlive = team.getFirstAlivePokemon();
     ASSERT_NE(firstAlive, nullptr);
-    EXPECT_EQ(firstAlive->name, "testmon2");
+    EXPECT_EQ(firstAlive->name, "testmonb");
     
     // Faint all Pokemon
     for (size_t i = 0; i < team.size(); ++i) {
@@ -282,13 +282,13 @@ TEST_F(TeamTest, MixedAliveAndFaintedPokemon) {
     
     std::vector<Pokemon*> alivePokemon = team.getAlivePokemon();
     EXPECT_EQ(alivePokemon.size(), 2);
-    EXPECT_EQ(alivePokemon[0]->name, "testmon1");
-    EXPECT_EQ(alivePokemon[1]->name, "testmon3");
+    EXPECT_EQ(alivePokemon[0]->name, "testmona");
+    EXPECT_EQ(alivePokemon[1]->name, "testmonc");
     
     // First alive should still be testmon1
     Pokemon* firstAlive = team.getFirstAlivePokemon();
     ASSERT_NE(firstAlive, nullptr);
-    EXPECT_EQ(firstAlive->name, "testmon1");
+    EXPECT_EQ(firstAlive->name, "testmona");
 }
 
 // Test team with Pokemon that have moves


### PR DESCRIPTION
- Rename test Pokemon from testmon1/2/3 to testmona/b/c to use only alphabetic characters
- Update Pokemon IDs from 1001-1003 to 901-903 to fit within valid range (1-999)
- Update all test assertions in test_team.cpp to reference new Pokemon names
- Resolves all TeamTest failures by ensuring test data passes validation

All 302 tests now pass successfully.